### PR TITLE
Add biber package for Ubuntu installations

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -53,7 +53,7 @@ installLinux()
     wily);;
     *) echo "${codename} not yet supported."; exit 1;;
   esac
-  sudo apt-get install texlive latexmk texlive-latex-extra texlive-publishers cmake
+  sudo apt-get install texlive latexmk texlive-latex-extra texlive-publishers cmake biber
   installMMD5
 
 }


### PR DESCRIPTION
This may fix an issue uncovered by @newtonj in installing Scriptorium on new Ubuntu installations. biber is used/assumed, but not installed by default. This may be due to package dependencies changing, or simply a missed package.
