### PR TITLE
add Vi/Vim swap files to auto-generated .gitignores

### DIFF
--- a/scriptorium/data/gitignore
+++ b/scriptorium/data/gitignore
@@ -29,4 +29,6 @@ paper.aux
 *.blg
 *.lof
 *.lot
+*.swp
+*.swo
 *~


### PR DESCRIPTION
This prevents swap files from being included in git commits. Nice for Vim users, but not a critical thing.
