### PR TITLE
Add bash autocompletion, requiring a single user command to enable

### DIFF
--- a/scriptorium/__main__.py
+++ b/scriptorium/__main__.py
@@ -2,6 +2,7 @@
 #Script to build a scriptorium paper in a cross-platform friendly fashion
 
 import argparse
+import argcomplete
 import shutil
 import sys
 import os
@@ -133,6 +134,7 @@ def main():
     config_parser.add_argument('value', nargs='*', help='Access configuration value')
     config_parser.set_defaults(func=config_cmd)
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     if 'func' in args:

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
         'console_scripts': ['scriptorium = scriptorium:main'],
     },
     package_data={'scriptorium': ['data/gitignore']},
-    install_requires=['pyyaml']
+    install_requires=['pyyaml', 'argcomplete']
     )


### PR DESCRIPTION
`eval "$(register-python-argcomplete scriptorium)"`

Fixes #20
