### PR TITLE
Remove outdated multimarkdown binary reference and fix indentation.

### DIFF
--- a/scriptorium/install.py
+++ b/scriptorium/install.py
@@ -6,9 +6,8 @@ import platform
 from collections import defaultdict
 
 REQUIRED_PACKAGES = {
-  'git': ['git'],
-  'latex': ['pdflatex', 'biber'],
-  'multimarkdown': ['multimarkdown']
+    'git': ['git'],
+    'latex': ['pdflatex', 'biber']
 }
 
 SPLIT_TOKENS = {


### PR DESCRIPTION
Multimarkdown is now integrated through pymmd, thus the binary form is no longer required.