### PR TITLE
Fix building documents with Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - texlive-fonts-recommended
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"

--- a/scriptorium/papers.py
+++ b/scriptorium/papers.py
@@ -17,7 +17,7 @@ import pymmd
 
 import scriptorium
 
-_BLANK_LINK = bytearray('\n\n', 'utf-8') if sys.version_info >= (3,0) else '\n\n'
+_BLANK_LINK = bytes('\n\n', 'utf-8') if sys.version_info >= (3,0) else '\n\n'
 
 def _list_files(dname):
     """Builds list of all files which could be converted via MultiMarkdown."""

--- a/scriptorium/papers.py
+++ b/scriptorium/papers.py
@@ -17,7 +17,7 @@ import pymmd
 
 import scriptorium
 
-_BLANK_LINK = bytes('\n\n', 'utf-8') if sys.version_info >= (3,0) else '\n\n'
+_BLANK_LINE = bytes('\n\n', 'utf-8') if sys.version_info >= (3,0) else '\n\n'
 
 def _list_files(dname):
     """Builds list of all files which could be converted via MultiMarkdown."""
@@ -51,7 +51,7 @@ def get_template(fname):
         return None
     with open(fname, 'r') as mmd_fp:
         mmf = mmap.mmap(mmd_fp.fileno(), 0, access=mmap.ACCESS_READ)
-        idx = mmf.find(_BLANK_LINK)
+        idx = mmf.find(_BLANK_LINE)
         if idx == -1:
             idx = mmf.size()
         mmf.seek(0)


### PR DESCRIPTION
This fixes #88, in which Python 3.4 requires the use of `bytes` for describing the blank line marker, as opposed to `bytesarray` which was used previously.